### PR TITLE
 P1: MCP - getArtistProfile

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -5,29 +5,41 @@ import { handleGetPosts } from "../lib/handlers/postsHandler";
 import { handleGetArtistProfile } from "../lib/handlers/artistProfileHandler";
 import { TOOL_CONFIGS } from "../lib/toolConfigs";
 
+const log = (level: string, message: string, data?: any) => {
+  console.log(
+    JSON.stringify({
+      level,
+      message,
+      data,
+      timestamp: new Date().toISOString(),
+      service: "mcp-server",
+    })
+  );
+};
+
 const handler = initializeMcpApiHandler(
   (server) => {
     // Add global error handler
     server.server.onerror = (error) => {
-      console.error("[MCP Server] Error:", error);
+      log("error", "MCP Server Error", {
+        error: error instanceof Error ? error.message : "Unknown error",
+        stack: error instanceof Error ? error.stack : undefined,
+      });
     };
 
     // Wrap tool handlers with error logging
     const wrapHandler = (handler: Function, toolName: string) => {
       return async (...args: any[]) => {
-        console.log(
-          `[${toolName}] Starting with args:`,
-          JSON.stringify(args, null, 2)
-        );
+        log("info", `Starting ${toolName}`, { args });
         try {
           const result = await handler(...args);
-          console.log(
-            `[${toolName}] Success:`,
-            JSON.stringify(result, null, 2)
-          );
+          log("info", `${toolName} succeeded`, { result });
           return result;
         } catch (error) {
-          console.error(`[${toolName}] Error:`, error);
+          log("error", `${toolName} failed`, {
+            error: error instanceof Error ? error.message : "Unknown error",
+            stack: error instanceof Error ? error.stack : undefined,
+          });
           throw error;
         }
       };

--- a/api/server.ts
+++ b/api/server.ts
@@ -7,25 +7,51 @@ import { TOOL_CONFIGS } from "../lib/toolConfigs";
 
 const handler = initializeMcpApiHandler(
   (server) => {
+    // Add global error handler
+    server.server.onerror = (error) => {
+      console.error("[MCP Server] Error:", error);
+    };
+
+    // Wrap tool handlers with error logging
+    const wrapHandler = (handler: Function, toolName: string) => {
+      return async (...args: any[]) => {
+        console.log(
+          `[${toolName}] Starting with args:`,
+          JSON.stringify(args, null, 2)
+        );
+        try {
+          const result = await handler(...args);
+          console.log(
+            `[${toolName}] Success:`,
+            JSON.stringify(result, null, 2)
+          );
+          return result;
+        } catch (error) {
+          console.error(`[${toolName}] Error:`, error);
+          throw error;
+        }
+      };
+    };
+
     server.tool(
       TOOL_CONFIGS.GET_ARTIST_PROFILE.name,
       TOOL_CONFIGS.GET_ARTIST_PROFILE.description,
       TOOL_CONFIGS.GET_ARTIST_PROFILE.parameters,
-      handleGetArtistProfile
+      wrapHandler(handleGetArtistProfile, "GET_ARTIST_PROFILE")
     );
 
     server.tool(
       TOOL_CONFIGS.GET_FANS.name,
       TOOL_CONFIGS.GET_FANS.description,
       TOOL_CONFIGS.GET_FANS.parameters,
-      handleGetFans
+      wrapHandler(handleGetFans, "GET_FANS")
     );
 
     server.tool(
       TOOL_CONFIGS.GET_POSTS.name,
       TOOL_CONFIGS.GET_POSTS.description,
       TOOL_CONFIGS.GET_POSTS.parameters,
-      handleGetPosts
+      wrapHandler(handleGetPosts, "GET_POSTS")
     );
   },
   {

--- a/api/server.ts
+++ b/api/server.ts
@@ -2,16 +2,25 @@ import { z } from "zod";
 import { initializeMcpApiHandler } from "../lib/mcp-api-handler";
 import { handleGetFans } from "../lib/handlers/fansHandler";
 import { handleGetPosts } from "../lib/handlers/postsHandler";
+import { handleGetArtistProfile } from "../lib/handlers/artistProfileHandler";
 import { TOOL_CONFIGS } from "../lib/toolConfigs";
 
 const handler = initializeMcpApiHandler(
   (server) => {
+    server.tool(
+      TOOL_CONFIGS.GET_ARTIST_PROFILE.name,
+      TOOL_CONFIGS.GET_ARTIST_PROFILE.description,
+      TOOL_CONFIGS.GET_ARTIST_PROFILE.parameters,
+      handleGetArtistProfile
+    );
+
     server.tool(
       TOOL_CONFIGS.GET_FANS.name,
       TOOL_CONFIGS.GET_FANS.description,
       TOOL_CONFIGS.GET_FANS.parameters,
       handleGetFans
     );
+
     server.tool(
       TOOL_CONFIGS.GET_POSTS.name,
       TOOL_CONFIGS.GET_POSTS.description,

--- a/lib/RecoupAPI/artistProfile.ts
+++ b/lib/RecoupAPI/artistProfile.ts
@@ -45,16 +45,29 @@ export type ArtistProfileQueryParams = z.infer<typeof ArtistProfileQuerySchema>;
 export async function getArtistProfile(
   params: ArtistProfileQueryParams
 ): Promise<ArtistProfileResponse> {
-  console.log("[getArtistProfile] Starting with params:", params);
+  // Use Response.json() for structured logging
+  const log = (level: string, message: string, data?: any) => {
+    console.log(
+      JSON.stringify({
+        level,
+        message,
+        data,
+        timestamp: new Date().toISOString(),
+        service: "artist-profile",
+      })
+    );
+  };
+
+  log("info", "Starting getArtistProfile", { params });
 
   try {
     const validatedParams = ArtistProfileQuerySchema.parse(params);
-    console.log("[getArtistProfile] Params validation successful");
+    log("info", "Params validation successful");
 
     const queryParams = new URLSearchParams();
     queryParams.append("artist_account_id", validatedParams.artist_account_id);
     const url = `${API_BASE_URL}/artist-profile?${queryParams.toString()}`;
-    console.log("[getArtistProfile] Making request to:", url);
+    log("info", "Making API request", { url });
 
     const response = await fetch(url, {
       headers: {
@@ -63,38 +76,33 @@ export async function getArtistProfile(
       },
     });
 
-    console.log("[getArtistProfile] Response status:", response.status);
-    console.log(
-      "[getArtistProfile] Response headers:",
-      Object.fromEntries(response.headers.entries())
-    );
+    log("info", "Received API response", {
+      status: response.status,
+      statusText: response.statusText,
+      headers: Object.fromEntries(response.headers.entries()),
+    });
 
     if (!response.ok) {
       throw new Error(`Failed to fetch artist profile: ${response.statusText}`);
     }
 
     const data = await response.json();
-    console.log(
-      "[getArtistProfile] Raw response data:",
-      JSON.stringify(data, null, 2)
-    );
+    log("info", "Received API data", { data });
 
     if (data.status === "error") {
       throw new Error(data.message || "Failed to fetch artist profile");
     }
 
     const parsedData = ArtistProfileResponseSchema.parse(data);
-    console.log("[getArtistProfile] Schema validation successful");
+    log("info", "Schema validation successful");
 
     return parsedData;
   } catch (error) {
-    console.error("[getArtistProfile] Error:", error);
-    if (error instanceof z.ZodError) {
-      console.error(
-        "[getArtistProfile] Validation errors:",
-        JSON.stringify(error.errors, null, 2)
-      );
-    }
+    log("error", "Error in getArtistProfile", {
+      error: error instanceof Error ? error.message : "Unknown error",
+      stack: error instanceof Error ? error.stack : undefined,
+      validation: error instanceof z.ZodError ? error.errors : undefined,
+    });
     throw error;
   }
 }

--- a/lib/RecoupAPI/artistProfile.ts
+++ b/lib/RecoupAPI/artistProfile.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import { API_BASE_URL } from "./constants";
+
+// Profile schema for individual social media profiles
+export const SocialProfileSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  profile_url: z.string().url(),
+  avatar: z.string().url().nullable(),
+  bio: z.string().nullable(),
+  follower_count: z.number().nullable(),
+  following_count: z.number().nullable(),
+  post_count: z.number().nullable(),
+  region: z.string().nullable(),
+  updated_at: z.string().datetime(),
+});
+
+// Complete artist profile schema
+export const ArtistProfileSchema = z.object({
+  id: z.string(),
+  profiles: z.array(SocialProfileSchema),
+  total_followers: z.number(),
+  total_following: z.number(),
+  total_posts: z.number(),
+  updated_at: z.string().datetime(),
+});
+
+// Response schema
+export const ArtistProfileResponseSchema = z.object({
+  status: z.enum(["success", "error"]),
+  profile: ArtistProfileSchema,
+});
+
+// Query parameters schema
+export const ArtistProfileQuerySchema = z.object({
+  artist_account_id: z.string(),
+});
+
+// Type exports
+export type SocialProfile = z.infer<typeof SocialProfileSchema>;
+export type ArtistProfile = z.infer<typeof ArtistProfileSchema>;
+export type ArtistProfileResponse = z.infer<typeof ArtistProfileResponseSchema>;
+export type ArtistProfileQueryParams = z.infer<typeof ArtistProfileQuerySchema>;
+
+export async function getArtistProfile(
+  params: ArtistProfileQueryParams
+): Promise<ArtistProfileResponse> {
+  const validatedParams = ArtistProfileQuerySchema.parse(params);
+  const queryParams = new URLSearchParams();
+  queryParams.append("artist_account_id", validatedParams.artist_account_id);
+
+  const response = await fetch(
+    `${API_BASE_URL}/artist-profile?${queryParams.toString()}`,
+    {
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch artist profile: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+
+  if (data.status === "error") {
+    throw new Error(data.message || "Failed to fetch artist profile");
+  }
+
+  return ArtistProfileResponseSchema.parse(data);
+}

--- a/lib/handlers/artistProfileHandler.ts
+++ b/lib/handlers/artistProfileHandler.ts
@@ -1,0 +1,41 @@
+import { getArtistProfile } from "../RecoupAPI/artistProfile";
+
+export const handleGetArtistProfile = async ({
+  artist_account_id,
+}: {
+  artist_account_id: string;
+}) => {
+  const response = await getArtistProfile({ artist_account_id });
+  const { profile } = response;
+
+  // Create a summary of each social media profile
+  const profileSummaries = profile.profiles
+    .map(
+      (p) =>
+        `Platform: ${new URL(p.profile_url).hostname}\n` +
+        `Username: ${p.username}\n` +
+        `Profile: ${p.profile_url}\n` +
+        `Bio: ${p.bio || "N/A"}\n` +
+        `Followers: ${p.follower_count?.toLocaleString() || "N/A"}\n` +
+        `Following: ${p.following_count?.toLocaleString() || "N/A"}\n` +
+        `Posts: ${p.post_count?.toLocaleString() || "N/A"}\n` +
+        `Region: ${p.region || "N/A"}`
+    )
+    .join("\n\n");
+
+  // Create overall statistics summary
+  const overallStats =
+    `Total Followers: ${profile.total_followers.toLocaleString()}\n` +
+    `Total Following: ${profile.total_following.toLocaleString()}\n` +
+    `Total Posts: ${profile.total_posts.toLocaleString()}\n` +
+    `Last Updated: ${new Date(profile.updated_at).toLocaleString()}`;
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Artist Profile Summary\n\nOverall Statistics:\n${overallStats}\n\nSocial Media Profiles:\n\n${profileSummaries}`,
+      },
+    ],
+  };
+};

--- a/lib/handlers/artistProfileHandler.ts
+++ b/lib/handlers/artistProfileHandler.ts
@@ -5,37 +5,63 @@ export const handleGetArtistProfile = async ({
 }: {
   artist_account_id: string;
 }) => {
-  const response = await getArtistProfile({ artist_account_id });
-  const { profile } = response;
+  console.log(
+    "[handleGetArtistProfile] Starting with artist_account_id:",
+    artist_account_id
+  );
 
-  // Create a summary of each social media profile
-  const profileSummaries = profile.profiles
-    .map(
-      (p) =>
-        `Platform: ${new URL(p.profile_url).hostname}\n` +
-        `Username: ${p.username}\n` +
-        `Profile: ${p.profile_url}\n` +
-        `Bio: ${p.bio || "N/A"}\n` +
-        `Followers: ${p.follower_count?.toLocaleString() || "N/A"}\n` +
-        `Following: ${p.following_count?.toLocaleString() || "N/A"}\n` +
-        `Posts: ${p.post_count?.toLocaleString() || "N/A"}\n` +
-        `Region: ${p.region || "N/A"}`
-    )
-    .join("\n\n");
+  try {
+    console.log("[handleGetArtistProfile] Calling getArtistProfile");
+    const response = await getArtistProfile({ artist_account_id });
+    console.log("[handleGetArtistProfile] Got response from getArtistProfile");
 
-  // Create overall statistics summary
-  const overallStats =
-    `Total Followers: ${profile.total_followers.toLocaleString()}\n` +
-    `Total Following: ${profile.total_following.toLocaleString()}\n` +
-    `Total Posts: ${profile.total_posts.toLocaleString()}\n` +
-    `Last Updated: ${new Date(profile.updated_at).toLocaleString()}`;
+    const { profile } = response;
+    console.log(
+      "[handleGetArtistProfile] Profile data:",
+      JSON.stringify(profile, null, 2)
+    );
 
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: `Artist Profile Summary\n\nOverall Statistics:\n${overallStats}\n\nSocial Media Profiles:\n\n${profileSummaries}`,
-      },
-    ],
-  };
+    // Create a summary of each social media profile
+    console.log("[handleGetArtistProfile] Creating profile summaries");
+    const profileSummaries = profile.profiles
+      .map(
+        (p) =>
+          `Platform: ${new URL(p.profile_url).hostname}\n` +
+          `Username: ${p.username}\n` +
+          `Profile: ${p.profile_url}\n` +
+          `Bio: ${p.bio || "N/A"}\n` +
+          `Followers: ${p.follower_count?.toLocaleString() || "N/A"}\n` +
+          `Following: ${p.following_count?.toLocaleString() || "N/A"}\n` +
+          `Posts: ${p.post_count?.toLocaleString() || "N/A"}\n` +
+          `Region: ${p.region || "N/A"}`
+      )
+      .join("\n\n");
+
+    // Create overall statistics summary
+    console.log("[handleGetArtistProfile] Creating overall stats");
+    const overallStats =
+      `Total Followers: ${profile.total_followers.toLocaleString()}\n` +
+      `Total Following: ${profile.total_following.toLocaleString()}\n` +
+      `Total Posts: ${profile.total_posts.toLocaleString()}\n` +
+      `Last Updated: ${new Date(profile.updated_at).toLocaleString()}`;
+
+    const result = {
+      content: [
+        {
+          type: "text" as const,
+          text: `Artist Profile Summary\n\nOverall Statistics:\n${overallStats}\n\nSocial Media Profiles:\n\n${profileSummaries}`,
+        },
+      ],
+    };
+
+    console.log(
+      "[handleGetArtistProfile] Returning result:",
+      JSON.stringify(result, null, 2)
+    );
+    return result;
+  } catch (error) {
+    console.error("[handleGetArtistProfile] Error:", error);
+    // Re-throw the error to be handled by MCP server
+    throw error;
+  }
 };

--- a/lib/handlers/artistProfileHandler.ts
+++ b/lib/handlers/artistProfileHandler.ts
@@ -1,28 +1,34 @@
 import { getArtistProfile } from "../RecoupAPI/artistProfile";
 
+const log = (level: string, message: string, data?: any) => {
+  console.log(
+    JSON.stringify({
+      level,
+      message,
+      data,
+      timestamp: new Date().toISOString(),
+      service: "artist-profile-handler",
+    })
+  );
+};
+
 export const handleGetArtistProfile = async ({
   artist_account_id,
 }: {
   artist_account_id: string;
 }) => {
-  console.log(
-    "[handleGetArtistProfile] Starting with artist_account_id:",
-    artist_account_id
-  );
+  log("info", "Starting handleGetArtistProfile", { artist_account_id });
 
   try {
-    console.log("[handleGetArtistProfile] Calling getArtistProfile");
+    log("info", "Calling getArtistProfile");
     const response = await getArtistProfile({ artist_account_id });
-    console.log("[handleGetArtistProfile] Got response from getArtistProfile");
+    log("info", "Got response from getArtistProfile");
 
     const { profile } = response;
-    console.log(
-      "[handleGetArtistProfile] Profile data:",
-      JSON.stringify(profile, null, 2)
-    );
+    log("info", "Processing profile data", { profile });
 
     // Create a summary of each social media profile
-    console.log("[handleGetArtistProfile] Creating profile summaries");
+    log("info", "Creating profile summaries");
     const profileSummaries = profile.profiles
       .map(
         (p) =>
@@ -38,7 +44,7 @@ export const handleGetArtistProfile = async ({
       .join("\n\n");
 
     // Create overall statistics summary
-    console.log("[handleGetArtistProfile] Creating overall stats");
+    log("info", "Creating overall stats");
     const overallStats =
       `Total Followers: ${profile.total_followers.toLocaleString()}\n` +
       `Total Following: ${profile.total_following.toLocaleString()}\n` +
@@ -54,14 +60,13 @@ export const handleGetArtistProfile = async ({
       ],
     };
 
-    console.log(
-      "[handleGetArtistProfile] Returning result:",
-      JSON.stringify(result, null, 2)
-    );
+    log("info", "Returning result", { result });
     return result;
   } catch (error) {
-    console.error("[handleGetArtistProfile] Error:", error);
-    // Re-throw the error to be handled by MCP server
+    log("error", "Error in handleGetArtistProfile", {
+      error: error instanceof Error ? error.message : "Unknown error",
+      stack: error instanceof Error ? error.stack : undefined,
+    });
     throw error;
   }
 };

--- a/lib/toolConfigs/recoupTools.ts
+++ b/lib/toolConfigs/recoupTools.ts
@@ -1,6 +1,14 @@
 import { z } from "zod";
 
 export const RecoupTools = {
+  GET_ARTIST_PROFILE: {
+    name: "get_artist_profile",
+    description:
+      "Get comprehensive profile information for an artist across all connected social media platforms",
+    parameters: {
+      artist_account_id: z.string(),
+    },
+  },
   GET_FANS: {
     name: "get_artist_fans",
     description:


### PR DESCRIPTION
   actual: The Message Control Plane (MCP) server currently lacks a tool that enables Recoup to query the getArtistProfile API endpoint, preventing access to comprehensive artist data during conversations.
   required: Implement a new tool in the MCP server that:
   Integrates with the existing /api/profile endpoint
   Accepts an artist_account_id parameter
   Returns formatted artist profile data from all social platforms
   Handles error cases gracefully with appropriate user feedback
   Is properly documented in the tools schema for Recoup to utilize
   This implementation will enable Recoup to automatically access comprehensive artist information across all social platforms during conversations, significantly enhancing contextual awareness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new capability for retrieving and displaying comprehensive artist profiles, including social media details and key statistics.
	- Enhanced the API to validate requests and format profile information clearly, ensuring a richer artist data experience for users.
	- Added a global error handler to improve error logging and handling for API requests.
	- Introduced a standardized logging mechanism for better visibility into API operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->